### PR TITLE
Fix "Unexpected value false parsing transform attribute."

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -111,6 +111,21 @@ function _render(callback) {
         }
         var tag = data.tag;
         var attributes = data.attributes;
+        var currentAttributes = element.node().attributes;
+        if (currentAttributes) {
+            for (var i = 0; i < currentAttributes.length; i++) {
+                var currentAttribute = currentAttributes[i];
+                var name = currentAttribute.name;
+                if (name.split(':')[0] != 'xmlns' && currentAttribute.namespaceURI) {
+                    var namespaceURIParts = currentAttribute.namespaceURI.split('/');
+                    var namespace = namespaceURIParts[namespaceURIParts.length - 1];
+                    name = namespace + ':' + name;
+                }
+                if (!(name in attributes)) {
+                    attributes[name] = null;
+                }
+            }
+        }
         var convertShape = false;
         var convertPrevShape = false;
         if (tweenShapes && transitionInstance) {
@@ -174,7 +189,6 @@ function _render(callback) {
                 .attr("stroke-dasharray", totalLength + " " + totalLength)
                 .attr("stroke-dashoffset", totalLength)
                 .attr('transform', 'translate(' + data.offset.x + ',' + data.offset.y + ')');
-            attributes["stroke-dasharray"] = false;
             attributes["stroke-dashoffset"] = 0;
             attributes['transform'] = 'translate(0,0)';
             elementTransition
@@ -202,7 +216,6 @@ function _render(callback) {
             var y = p0.y - p1.y + data.offset.y;
             element
                 .attr('transform', 'translate(' + x + ',' + y + ')');
-            attributes['transform'] = false;
             elementTransition
                 .attrTween("transform", function () {
                     return function (t) {
@@ -223,21 +236,6 @@ function _render(callback) {
                 });
         }
         var tweenThisPath = tweenPaths && transitionInstance && tag == 'path' && element.attr('d') != null;
-        var currentAttributes = element.node().attributes;
-        if (currentAttributes) {
-            for (var i = 0; i < currentAttributes.length; i++) {
-                var currentAttribute = currentAttributes[i];
-                var name = currentAttribute.name;
-                if (name.split(':')[0] != 'xmlns' && currentAttribute.namespaceURI) {
-                    var namespaceURIParts = currentAttribute.namespaceURI.split('/');
-                    var namespace = namespaceURIParts[namespaceURIParts.length - 1];
-                    name = namespace + ':' + name;
-                }
-                if (!(name in attributes)) {
-                    attributes[name] = null;
-                }
-            }
-        }
         for (var attributeName of Object.keys(attributes)) {
             var attributeValue = attributes[attributeName];
             if (tweenThisPath && attributeName == 'd') {
@@ -271,10 +269,8 @@ function _render(callback) {
                             }
                         })
                 }
-                if (attributeValue !== false) {
-                    elementTransition
-                        .attr(attributeName, attributeValue);
-                }
+                elementTransition
+                    .attr(attributeName, attributeValue);
             }
         }
         if (convertShape) {


### PR DESCRIPTION
By doing the removal of SVG element attributes before adding temporary
attributes used by e.g. tweening and growing.

This problem was introduced by an ill-thought soliutiuon in commit
7ad3af49cf54ec4b737c2454c5c5d08f1f10f29c.