### PR TITLE
Handle relative pathnames for local websites

### DIFF
--- a/src/dot.js
+++ b/src/dot.js
@@ -20,7 +20,7 @@ export function initViz() {
         };
         if (!vizURL.match(/^https?:\/\/|^\/\//i)) {
             // Local URL. Prepend with local domain to be usable in web worker
-            vizURL = document.location.protocol + '//' + document.location.host + '/' + vizURL;
+            vizURL = (new window.URL(vizURL, document.location.href)).href;
         }
         this._worker.postMessage({dot: "", vizURL: vizURL});
     }


### PR DESCRIPTION
In situations where this library is used for a local website, this
change handles the relative pathname of the viz.js script for the web
worker.

(References #61)