### PR TITLE
Fix undefined bug: Only set datum.offset if prevStartShape && startSh…

### DIFF
--- a/src/dot.js
+++ b/src/dot.js
@@ -207,9 +207,11 @@ export default function(src, callback) {
                                 break;
                             }
                         }
-                        datum.offset = {
-                            x: prevStartShape.center.x - startShape.center.x,
-                            y: prevStartShape.center.y - startShape.center.y,
+                        if (prevStartShape && startShape) {
+                            datum.offset = {
+                                x: prevStartShape.center.x - startShape.center.x,
+                                y: prevStartShape.center.y - startShape.center.y,
+                            };
                         }
                     }
                 }


### PR DESCRIPTION
…ape are defined

If the shapes tags doesn't match any of the values "polygon", "ellipse" or "path",
which can happen if you have a node with e.g. shape=none, then prevStartShape and/or startShape
will be undefined and an error will be thrown due to trying to get .center.

Fix by checking if both are defined, and then setting datum.offset.