### PR TITLE
Add support for zoom events

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Adds or removes a *listener* to the graphviz renderer instance for the specified
 * `transitionEnd` - when the anmiated transition ends.
 * `restoreEnd` - when possibly converted paths and shapes have been restored after the transition.
 * `end` - when the graphviz renderer has finished all actions.
+* `zoom` - when the layout has been zoomed.
 
 Note that these are *not* native DOM events as implemented by [*selection*.on](https://github.com/d3/d3-selection#selection_on) and [*selection*.dispatch](https://github.com/d3/d3-selection#selection_dispatch), but graphviz events!
 

--- a/src/graphviz.js
+++ b/src/graphviz.js
@@ -146,7 +146,8 @@ export function Graphviz(selection, options) {
         'transitionStart',
         'transitionEnd',
         'restoreEnd',
-        'end'
+        'end',
+        'zoom'
     ];
     this._dispatch = dispatch(...this._eventTypes);
     initViz.call(this);

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -14,10 +14,12 @@ export default function(enable) {
 }
 
 export function createZoomBehavior() {
-
+    
+    var graphvizInstance = this;
     function zoomed() {
         var g = d3.select(svg.node().querySelector("g"));
         g.attr('transform', d3.event.transform);
+        graphvizInstance._dispatch.call('zoom', graphvizInstance);
     }
 
     var root = this._selection;


### PR DESCRIPTION
Closes #112 

Adds a `'zoom'` event that can be listened to with `graphviz.on('zoom', ..)`.

For example,
```
.on('zoom', () => {
  console.log('graphviz zoomed with event:', d3.event);
});
```