### PR TITLE
Update @hpcc-js/wasm to 1.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Upgrade @hpcc-js/wasm to 1.15.7 (Graphviz unchanged at 5.0.1)  (thanks @mrdrogdrog)
+
 ## [4.2.0]
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hpcc-js/wasm": "1.15.4",
+        "@hpcc-js/wasm": "1.15.7",
         "d3-dispatch": "^2.0.0",
         "d3-format": "^2.0.0",
         "d3-interpolate": "^2.0.1",
@@ -1687,9 +1687,9 @@
       }
     },
     "node_modules/@hpcc-js/wasm": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.15.4.tgz",
-      "integrity": "sha512-I0SIpBItWJ5lIrlTiMM6GiOsWfeDHpWFaxbglmdWWtPLjN/eFLILVxm46dIxvqnjbwdj0mErxL5h4+znNVgs4A==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.15.7.tgz",
+      "integrity": "sha512-ScK2QU6kF3F0ZojBHefa8zAnMlNh0isZ+iFSB5yOshxHqZv8q3ly1wGQgrvFrhppvM0VvyLOo4Q5ipbQKZMhWQ==",
       "dependencies": {
         "yargs": "17.5.1"
       },
@@ -7164,9 +7164,9 @@
       }
     },
     "@hpcc-js/wasm": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.15.4.tgz",
-      "integrity": "sha512-I0SIpBItWJ5lIrlTiMM6GiOsWfeDHpWFaxbglmdWWtPLjN/eFLILVxm46dIxvqnjbwdj0mErxL5h4+znNVgs4A==",
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.15.7.tgz",
+      "integrity": "sha512-ScK2QU6kF3F0ZojBHefa8zAnMlNh0isZ+iFSB5yOshxHqZv8q3ly1wGQgrvFrhppvM0VvyLOo4Q5ipbQKZMhWQ==",
       "requires": {
         "yargs": "17.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "tiny-worker": "^2.1.2"
   },
   "dependencies": {
-    "@hpcc-js/wasm": "1.15.4",
+    "@hpcc-js/wasm": "1.15.7",
     "d3-dispatch": "^2.0.0",
     "d3-format": "^2.0.0",
     "d3-interpolate": "^2.0.1",


### PR DESCRIPTION
hpcc-js/wasm released a new version that fixes some serious problems when using next.js (probably it's a webpack/esbuild problem).

This PR updates @hpcc-js/wasm to 1.15.7.

See https://github.com/hpcc-systems/hpcc-js-wasm/issues/116 and https://github.com/hpcc-systems/hpcc-js-wasm/issues/115