### PR TITLE
fix failure to resolve entry for package "d3-graphviz"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+*  Failed to resolve entry for package "d3-graphviz" #263
+
 ## [5.0.0] – 2022-12-26
 
 **Note:** This release contains breaking changes compared to version 4.5.0.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "Viz.js"
   ],
   "license": "BSD-3-Clause",
-  "main": "build/d3-graphviz.cjs",
   "type": "module",
   "exports": "./src/index.js",
   "jsnext:main": "index",


### PR DESCRIPTION
This was a temporary solution while porting the test cases to ESM introduced in 04af0ab284ac078f982b0baedb5b4b58c75f3c99 instead of removing it in abc5c51f10bdbf01afdf5fe0fb43a65f297ac41f. Once the porting was done, the "main" entry should have been removed.

Fixes https://github.com/magjac/d3-graphviz/issues/263.