### PR TITLE
Upgrade @hpcc-js/wasm to 2.16.2 (Graphviz 11.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Upgrade @hpcc-js/wasm to 2.16.2 (Graphviz 11.0.0)
+
 ### Fixed
 * Cluster's box shadows nodes inside it after animated transition
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hpcc-js/wasm": "^2.16.0",
+        "@hpcc-js/wasm": "^2.16.2",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",
@@ -1774,9 +1774,9 @@
       "dev": true
     },
     "node_modules/@hpcc-js/wasm": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.16.0.tgz",
-      "integrity": "sha512-e2aPTthjER80Kt/BZPHKksm6YjyMul4qUDDbIxhZYjbUvrxy9ogDr81P4pa1DSUIMzQ1f/7yCC22SBYIa3j5gg==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.16.2.tgz",
+      "integrity": "sha512-THiidUMYR8/cIfFT3MVcWuRE7bQKh295nrFBxGvUNc4Nq8e2uU1LtiplHs7AUkJ0GxgvZoR+8TQ1/E3Qb/uE2g==",
       "dependencies": {
         "yargs": "17.7.2"
       },
@@ -7234,9 +7234,9 @@
       "dev": true
     },
     "@hpcc-js/wasm": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.16.0.tgz",
-      "integrity": "sha512-e2aPTthjER80Kt/BZPHKksm6YjyMul4qUDDbIxhZYjbUvrxy9ogDr81P4pa1DSUIMzQ1f/7yCC22SBYIa3j5gg==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.16.2.tgz",
+      "integrity": "sha512-THiidUMYR8/cIfFT3MVcWuRE7bQKh295nrFBxGvUNc4Nq8e2uU1LtiplHs7AUkJ0GxgvZoR+8TQ1/E3Qb/uE2g==",
       "requires": {
         "yargs": "17.7.2"
       }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tiny-worker": "^2.3.0"
   },
   "dependencies": {
-    "@hpcc-js/wasm": "^2.16.0",
+    "@hpcc-js/wasm": "^2.16.2",
     "d3-dispatch": "^3.0.1",
     "d3-format": "^3.1.0",
     "d3-interpolate": "^3.0.1",


### PR DESCRIPTION
Performed by:

npm upgrade @hpcc-js/wasm --save