### PR TITLE
upgrade @hpcc-js/wasm to 2.18.1 (Graphviz 12.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Upgrade @hpcc-js/wasm to 2.18.1 (Graphviz 12.0.0)
+
 ## [5.4.0] – 2024-05-05
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hpcc-js/wasm": "^2.16.2",
+        "@hpcc-js/wasm": "^2.18.1",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",
@@ -1791,9 +1791,9 @@
       "dev": true
     },
     "node_modules/@hpcc-js/wasm": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.16.2.tgz",
-      "integrity": "sha512-THiidUMYR8/cIfFT3MVcWuRE7bQKh295nrFBxGvUNc4Nq8e2uU1LtiplHs7AUkJ0GxgvZoR+8TQ1/E3Qb/uE2g==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.18.1.tgz",
+      "integrity": "sha512-fT8NCOTaF0NDnT+ZwWpV2VQ6ywFEqw+fG87GSPNQemEmg7FFqUaKRQOW9MBICrkZcXaJBb7VHo1t5UF6bi/JgQ==",
       "dependencies": {
         "yargs": "17.7.2"
       },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tiny-worker": "^2.3.0"
   },
   "dependencies": {
-    "@hpcc-js/wasm": "^2.16.2",
+    "@hpcc-js/wasm": "^2.18.1",
     "d3-dispatch": "^3.0.1",
     "d3-format": "^3.1.0",
     "d3-interpolate": "^3.0.1",

--- a/test/@hpcc-js/wasm/dist/wrapper.js
+++ b/test/@hpcc-js/wasm/dist/wrapper.js
@@ -1,4 +1,4 @@
 const vizURL = 'node_modules/@hpcc-js/wasm/dist/graphviz.umd.js';
 importScripts(vizURL);
-self["@hpcc-js/wasm"] = global["@hpcc-js/wasm"];
+self["@hpcc-js/wasm"] = window["@hpcc-js/wasm"];
 global.document = {};


### PR DESCRIPTION
Performed by:

npm upgrade @hpcc-js/wasm --save

Also adapt wrapper.js to @hpcc-js/wasm change in version 2.17.0. It's unclear what change caused "@hpcc-js/wasm" to move from `global` to `window`