### PR TITLE
upgrade @hpcc-js/wasm to 2.20.0 (Graphviz 12.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* Upgrade @hpcc-js/wasm to 2.20.0 (Graphviz 12.1.0)
+
 ## [5.5.0] – 2024-08-17
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hpcc-js/wasm": "^2.18.1",
+        "@hpcc-js/wasm": "^2.20.0",
         "d3-dispatch": "^3.0.1",
         "d3-format": "^3.1.0",
         "d3-interpolate": "^3.0.1",
@@ -1791,14 +1791,14 @@
       "dev": true
     },
     "node_modules/@hpcc-js/wasm": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.18.1.tgz",
-      "integrity": "sha512-fT8NCOTaF0NDnT+ZwWpV2VQ6ywFEqw+fG87GSPNQemEmg7FFqUaKRQOW9MBICrkZcXaJBb7VHo1t5UF6bi/JgQ==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-2.20.0.tgz",
+      "integrity": "sha512-LBjTs1s0ekEp/D4skkfsxCYWt3/1eHZx6JDnV9cu5tqPOERHdbdRukhE7nr/jExBuFfkh/cTW9aGvkbfp5Hbuw==",
       "dependencies": {
         "yargs": "17.7.2"
       },
       "bin": {
-        "dot-wasm": "bin/dot-wasm.js"
+        "dot-wasm": "node ./node_modules/@hpcc-js/wasm-graphviz-cli/bin/index.js"
       }
     },
     "node_modules/@istanbuljs/schema": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "tiny-worker": "^2.3.0"
   },
   "dependencies": {
-    "@hpcc-js/wasm": "^2.18.1",
+    "@hpcc-js/wasm": "^2.20.0",
     "d3-dispatch": "^3.0.1",
     "d3-format": "^3.1.0",
     "d3-interpolate": "^3.0.1",

--- a/test/@hpcc-js/wasm/dist/wrapper.js
+++ b/test/@hpcc-js/wasm/dist/wrapper.js
@@ -1,4 +1,4 @@
 const vizURL = 'node_modules/@hpcc-js/wasm/dist/graphviz.umd.js';
 importScripts(vizURL);
-self["@hpcc-js/wasm"] = window["@hpcc-js/wasm"];
+self["@hpcc-js/wasm"] = global["@hpcc-js/wasm"];
 global.document = {};


### PR DESCRIPTION
Performed by:

npm upgrade @hpcc-js/wasm --save

Also revert the change to wrapper.js added in
761aeec8ab432ba8102b70924bfce6859df79817 which was an adaptation to a
@hpcc-js/wasm change in version 2.17.0 that no longer is correct. It's
unclear what change caused @hpcc-js/wasm to move from using `window`
back to using `global` again.
