### PR TITLE
Port codecov to use Codecov's Github Action dedicated wrapper

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,3 +27,10 @@ jobs:
       - run: npm run build --if-present
       - run: npm test
       - run: npm run coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          file: ./coverage.lcov
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "env TESTRUNNER='c8 --reporter=text mocha' npm run do-test",
     "do-test": "mkdir -p http:; ln -nsf .. http://dummyhost; $TESTRUNNER 'test/**/*-test.js' 'test/**/*-test.cjs'",
     "report": "c8 report --reporter=lcov",
-    "coverage": "c8 report --reporter=text-lcov > coverage.lcov && codecov",
+    "coverage": "c8 report --reporter=text-lcov > coverage.lcov",
     "prepublishOnly": "env NODE_ENV=production npm run build && terser build/d3-graphviz.js -c -m -o build/d3-graphviz.min.js",
     "prepublishOnlyOriginal": "env NODE_ENV=production npm run build && TESTRUNNER='mocha' npm run do-test && terser build/d3-graphviz.js -c -m -o build/d3-graphviz.min.js",
     "publicbuild": "env NODE_ENV=production npm run build",


### PR DESCRIPTION
The immediate reason for doing this is that running codecov failed with:

```
==> Uploading reports
/home/magjac/d3-graphviz/node_modules/codecov/lib/codecov.js:217
      } else if (result.split('\n').length !== 2) {
                        ^

TypeError: result.split is not a function
    at /home/magjac/d3-graphviz/node_modules/codecov/lib/codecov.js:217:25
    at /home/magjac/d3-graphviz/node_modules/teeny-request/build/src/index.js:217:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.19.1
```

The Codecov NodeJS Uploader¹ has been deprecated and seems to no longer work. Instead, uploading reports to Codecov using the Codecov CLI² is now recommeded. This change does this using the Codecov GitHub Action³.

¹ https://github.com/codecov/codecov-node
² https://docs.codecov.com/docs/codecov-uploader
³ https://github.com/marketplace/actions/codecov